### PR TITLE
[ENHANCEMENT] add batch execution support

### DIFF
--- a/src/eval.ts
+++ b/src/eval.ts
@@ -189,10 +189,6 @@ function orderByDependencies(variables: Variable[]) {
   return order;
 }
 
-export function evaluateBatch(batch: Variable[], count = 1): Evaluation[] {
-  return batch.map((v: Variable) => evaluate([v], count)[0]);
-}
-
 /**
  * Evaluate a list of expressions, returning a list of Evaluations of size count
  * @param {Variable[]} variables
@@ -204,10 +200,13 @@ export function evaluate(variables: Variable[], count: number = 1): Evaluation[]
   /*
     Second generation dynamic question editor
   */
-  if (variables.length === 1 && variables[0].variable === 'module') {
-    // Run the evaluation `count` times
-    return aggregateResults(
-      [...Array(count).fill(undefined)].map(_ => runModule(variables[0].expression)));
+
+  if (variables.every(v => v.variable === 'module')) {
+
+    const result = variables.map(v => {
+      aggregateResults([...Array(count).fill(undefined)].map(_ => runModule(variables[0].expression)));
+    });
+    return (result as any) as Evaluation[];
   }
 
   /*

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -189,6 +189,10 @@ function orderByDependencies(variables: Variable[]) {
   return order;
 }
 
+export function evaluateBatch(batch: Variable[], count = 1): Evaluation[] {
+  return batch.map((v: Variable) => evaluate([v], count)[0]);
+}
+
 /**
  * Evaluate a list of expressions, returning a list of Evaluations of size count
  * @param {Variable[]} variables
@@ -302,5 +306,5 @@ function aggregateResults(results: Evaluation[][]): Evaluation[] {
       right: map => evaluationsFromMap(map),
     });
 
-  return listFromEither(reduceResultsToEither(results));
+  return listFromEither(reduceResultsToEither(results) as any);
 }

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -204,7 +204,7 @@ export function evaluate(variables: Variable[], count: number = 1): Evaluation[]
   if (variables.every(v => v.variable === 'module')) {
 
     const result = variables.map(v => {
-      aggregateResults([...Array(count).fill(undefined)].map(_ => runModule(variables[0].expression)));
+      return aggregateResults([...Array(count).fill(undefined)].map(_ => runModule(v.expression)));
     });
     return (result as any) as Evaluation[];
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import * as bodyParser from 'body-parser';
 import * as express from 'express';
 import * as cluster from 'express-cluster';
-import { evaluate, evaluateBatch } from './eval';
+import { evaluate } from './eval';
 
 cluster(
   (worker: any) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,10 +15,6 @@ cluster(
       res.send(evaluate(req.body.vars, req.body.count));
     });
 
-    router.post('/batch', (req: any, res: any) => {
-      res.send(evaluateBatch(req.body.vars, req.body.count));
-    });
-
     app.use('/', router);
 
     return app.listen(8000, '0.0.0.0', () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import * as bodyParser from 'body-parser';
 import * as express from 'express';
 import * as cluster from 'express-cluster';
-import { evaluate } from './eval';
+import { evaluate, evaluateBatch } from './eval';
 
 cluster(
   (worker: any) => {
@@ -12,8 +12,11 @@ cluster(
     app.use(bodyParser.urlencoded({ extended: true }));
 
     router.post('/sandbox', (req: any, res: any) => {
-      console.log(req.body);
       res.send(evaluate(req.body.vars, req.body.count));
+    });
+
+    router.post('/batch', (req: any, res: any) => {
+      res.send(evaluateBatch(req.body.vars, req.body.count));
     });
 
     app.use('/', router);

--- a/test/batch-test.ts
+++ b/test/batch-test.ts
@@ -1,0 +1,20 @@
+
+const evaluate = require('../src/eval').evaluate;
+
+describe('batch execution', () => {
+
+  const batch = [
+    { variable: 'module', expression: 'module.exports = { test: 1, test1: 2 };'},
+    { variable: 'module', expression: 'module.exports = { test: 2 };'},
+    { variable: 'module', expression: 'module.exports = { test: 3, a: 1, b: 2};'}
+  ];
+
+  test('batch execution', () => {
+    const result = evaluate(batch, 5);
+    expect(result.length).toBe(3);
+    expect(result[0].length).toBe(2);
+    expect(result[1].length).toBe(1);
+    expect(result[2].length).toBe(3);
+  });
+
+});


### PR DESCRIPTION
This PR adds batch execution support for the existing `sandbox` route.  

The change allows any number of `module` type JS scripts to be passed in.  All are executed serially, then their results are returned back as one payload. 

The intent here is that this impl is 100% backwards compatible with Echo and Legacy OLI.  