### PR TITLE
Add docker compose and haproxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *~
+/.idea/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,12 @@ services:
       options:
         syslog-address: udp://localhost:514
         syslog-facility: local1
-        tag: "oli.eval_engine"
+        tag: "eval-engine"
   ha-proxy:
     build: ./ha-proxy
-    image: torus/haproxy
+    image: eval/haproxy
     restart: always
-    container_name: torus-haproxy
+    container_name: eval-haproxy
     ports:
     - "80:80"
     - "443:443"
@@ -32,7 +32,7 @@ services:
       options:
         syslog-address: udp://localhost:514
         syslog-facility: local1
-        tag: "torus.torus-haproxy"
+        tag: "eval-haproxy"
 networks:
   service-tier:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.1'
+services:
+  eval-engine:
+    build: ./
+    image: torus/eval_engine
+    restart: always
+    container_name: eval_engine
+    networks:
+    - service-tier
+    logging:
+      driver: syslog
+      options:
+        syslog-address: udp://localhost:514
+        syslog-facility: local1
+        tag: "oli.eval_engine"
+  ha-proxy:
+    build: ./ha-proxy
+    image: torus/haproxy
+    restart: always
+    container_name: torus-haproxy
+    ports:
+    - "80:80"
+    - "443:443"
+    volumes:
+    - /etc/pki/tls/certs/haproxy:/certs
+    networks:
+    - service-tier
+    depends_on:
+    - eval-engine
+    logging:
+      driver: syslog
+      options:
+        syslog-address: udp://localhost:514
+        syslog-facility: local1
+        tag: "torus.torus-haproxy"
+networks:
+  service-tier:
+    driver: bridge

--- a/ha-proxy/Dockerfile
+++ b/ha-proxy/Dockerfile
@@ -1,0 +1,3 @@
+FROM haproxy:1.8
+COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
+RUN mkdir /certs

--- a/ha-proxy/haproxy.cfg
+++ b/ha-proxy/haproxy.cfg
@@ -1,0 +1,30 @@
+global
+    daemon
+    maxconn 2048
+    tune.ssl.default-dh-param 2048
+    log /dev/log local0 info
+    # Default ciphers to use on SSL-enabled listening sockets.
+    # For more information, see ciphers(1SSL). This list is from:
+    #  https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
+    ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
+    ssl-default-bind-options no-sslv3
+
+defaults
+    mode    http
+    timeout connect 5000ms
+    timeout client 50000ms
+    timeout server 50000ms
+
+frontend www-https
+    bind *:80
+    bind *:443 ssl crt /certs/combined.pem
+    option forwardfor
+    http-request add-header X-Proto https
+    http-request add-header X-Forwarded-Proto https
+    http-request add-header X-Client-IP %[src]
+    http-request set-header Scheme https
+    default_backend eval-engine
+
+backend eval-engine
+    redirect scheme https if !{ ssl_fc }
+    server eval_engine eval-engine:8000 check

--- a/ha-proxy/haproxy.cfg
+++ b/ha-proxy/haproxy.cfg
@@ -28,4 +28,4 @@ frontend www-https
 
 backend eval-engine
     redirect scheme https if !{ ssl_fc }
-    server eval_engine eval-engine:8000 check
+    server eval_engine1 eval-engine:8000 check

--- a/ha-proxy/haproxy.cfg
+++ b/ha-proxy/haproxy.cfg
@@ -11,6 +11,7 @@ global
 
 defaults
     mode    http
+    log     global
     timeout connect 5000ms
     timeout client 50000ms
     timeout server 50000ms

--- a/ha-proxy/haproxy.cfg
+++ b/ha-proxy/haproxy.cfg
@@ -2,7 +2,7 @@ global
     daemon
     maxconn 2048
     tune.ssl.default-dh-param 2048
-    log /dev/log local0 info
+    log   127.0.0.1 local2
     # Default ciphers to use on SSL-enabled listening sockets.
     # For more information, see ciphers(1SSL). This list is from:
     #  https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/


### PR DESCRIPTION
This PR switches the eval engine launching to docker-compose and fronts the engine with Haproxy to support SSL termination to the API. 