### PR TITLE
[BUG FIX] Trim expression body

### DIFF
--- a/src/eval.ts
+++ b/src/eval.ts
@@ -212,8 +212,11 @@ function runFirstGen(variables: Variable[]) {
   // emJsReplaced: Variable[]
   const emJsReplaced = ordered
     .map((v) => {
-      if (v.expression.startsWith('em.emJs(')) {
-        let body = v.expression.substr(8);
+
+      const bodyExpression = v.expression.trim();
+
+      if (bodyExpression.startsWith('em.emJs(')) {
+        let body = bodyExpression.substr(8);
         body = body.substr(0, body.length - 1);
 
         return {


### PR DESCRIPTION
Certain V1 expressions can fail to evaluate when the use the `em.JS` function AND they have trailing whitespace after the closing `)`.  This PR trims the expression body before evaluating it. Verified locally that it fixes the problem. 