### PR TITLE
[BUG FIX] Convert stringified numbers to numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ts-jest": "^23.1.3",
     "tsconfig-paths": "^3.5.0",
     "tsmonad": "^0.8.0",
-    "vm2": "^3.6.0"
+    "vm2": "^3.9.19"
   },
   "devDependencies": {
     "@types/jest": "^23.3.1",

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -12,6 +12,24 @@ const algebra = require('algebra.js');
 const numeral = require('numeral');
 const _ = require('lodash');
 
+export function convertStringToNumber(value: any) {
+  // Check if the value is of type string
+  if (typeof value === 'string') {
+    // Attempt to convert the string to a number
+    const parsedNumber = Number(value);
+
+    // Check if the conversion is successful and not NaN
+    if (!isNaN(parsedNumber)) {
+      // Return the number, preserving its type (integer or float)
+      return parsedNumber;
+    }
+  }
+
+  // If the value is not a string or cannot be converted to a number,
+  // return the original value or handle it as needed
+  return value;
+}
+
 function run(expression: string) {
   const vm = new VM({
     timeout: 300,
@@ -19,7 +37,8 @@ function run(expression: string) {
   });
 
   try {
-    return vm.run(expression);
+    const result = vm.run(expression);
+    return convertStringToNumber(result);
   } catch (e) {
     return null;
   }

--- a/test/convert-test.ts
+++ b/test/convert-test.ts
@@ -1,0 +1,16 @@
+
+const convertStringToNumber = require('../src/eval').convertStringToNumber;
+
+describe('convert', () => {
+
+  test('converts correctly', () => {
+    expect(convertStringToNumber('1')).toBe(1);
+    expect(typeof convertStringToNumber('1')).toBe('number');
+    expect(convertStringToNumber('1.1')).toBe(1.1);
+    expect(convertStringToNumber('1.1.1')).toBe('1.1.1');
+    expect(convertStringToNumber('1 1 1')).toBe('1 1 1');
+    expect(convertStringToNumber(null)).toBe(null);
+    expect(convertStringToNumber('This is definitely a string')).toBe('This is definitely a string');
+  });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -456,9 +456,19 @@ acorn-globals@^4.1.0:
   dependencies:
     acorn "^5.0.0"
 
+acorn-walk@^8.2.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.2.tgz#7703af9415f1b6db9315d6895503862e231d34aa"
+  integrity sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==
+
 acorn@^5.0.0, acorn@^5.5.3:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
+
+acorn@^8.7.0:
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
+  integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
 ajv@^5.1.0:
   version "5.5.2"
@@ -4260,9 +4270,13 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vm2@^3.6.0:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.6.3.tgz#6dd426bb67a387d03055c5d276720f3f23203b72"
+vm2@^3.9.19:
+  version "3.9.19"
+  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.19.tgz#be1e1d7a106122c6c492b4d51c2e8b93d3ed6a4a"
+  integrity sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==
+  dependencies:
+    acorn "^8.7.0"
+    acorn-walk "^8.2.0"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR fixes an issue where, somehow previously, `vm.run` was returning values of type number when they were numbers, but now it always returns numbers as type 'string'.  This ends up breaking certain V1 questions where addition takes place like "@@V1@@ + @@V2@@" because the `+` operator is of course overloaded for string concatenation.  